### PR TITLE
feat(monitor): add uptime and latency charts using Chart.js

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -10,9 +10,11 @@
     "check‑types": "tsc --noEmit --build tsconfig.json"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
     "date-fns": "^4.1.0",
     "next": "15.3.5",
     "react": "^19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {

--- a/apps/frontend/src/components/monitors/MonitorDetailsComponent.tsx
+++ b/apps/frontend/src/components/monitors/MonitorDetailsComponent.tsx
@@ -9,6 +9,29 @@ import type {
 } from '@/types/monitor';
 import { formatRelative } from 'date-fns/formatRelative';
 import Link from 'next/link';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  ChartOptions,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+
+// Register Chart.js components
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
 
 interface MonitorDetailsComponentProps {
   monitor: Monitor;
@@ -101,18 +124,159 @@ function calculateStats(checkResults: CheckResult[]): MonitorStats {
   };
 }
 
+// Prepare chart data from check results
+function prepareChartData(checkResults: CheckResult[], timeRange: TimeRange) {
+  if (!checkResults.length) {
+    return { uptimeData: null, latencyData: null };
+  }
+
+  // Group data points for better visualization
+  const groupSize =
+    timeRange === '1h'
+      ? 6
+      : timeRange === '24h'
+        ? 12
+        : timeRange === '7d'
+          ? 24
+          : 48;
+  const groups: CheckResult[][] = [];
+
+  for (let i = 0; i < checkResults.length; i += groupSize) {
+    groups.push(checkResults.slice(i, i + groupSize));
+  }
+
+  const labels: string[] = [];
+  const uptimePercentages: number[] = [];
+  const avgLatencies: number[] = [];
+  const p95Latencies: number[] = [];
+
+  groups.forEach((group) => {
+    if (group.length === 0) return;
+
+    const firstCheck = group[0];
+    const upCount = group.filter((r) => r.status === 'UP').length;
+    const uptimePercentage = (upCount / group.length) * 100;
+
+    const latencies = group
+      .filter((r) => r.responseTimeMs !== undefined)
+      .map((r) => r.responseTimeMs!);
+
+    const avgLatency =
+      latencies.length > 0
+        ? latencies.reduce((sum, lat) => sum + lat, 0) / latencies.length
+        : 0;
+
+    const sortedLatencies = [...latencies].sort((a, b) => a - b);
+    const p95Index = Math.ceil(sortedLatencies.length * 0.95) - 1;
+    const p95Latency =
+      sortedLatencies.length > 0 ? sortedLatencies[p95Index] || 0 : 0;
+
+    // Format label based on time range
+    const date = new Date(firstCheck.timestamp);
+    let label = '';
+
+    if (timeRange === '1h') {
+      label = date.toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } else if (timeRange === '24h') {
+      label = date.toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } else if (timeRange === '7d') {
+      label = date.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+      });
+    } else {
+      label = date.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      });
+    }
+
+    labels.push(label);
+    uptimePercentages.push(Math.round(uptimePercentage * 100) / 100);
+    avgLatencies.push(Math.round(avgLatency));
+    p95Latencies.push(Math.round(p95Latency));
+  });
+
+  const uptimeData = {
+    labels,
+    datasets: [
+      {
+        label: 'Uptime %',
+        data: uptimePercentages,
+        borderColor: 'rgb(34, 197, 94)',
+        backgroundColor: 'rgba(34, 197, 94, 0.1)',
+        borderWidth: 2,
+        fill: true,
+        tension: 0.4,
+      },
+    ],
+  };
+
+  const latencyData = {
+    labels,
+    datasets: [
+      {
+        label: 'Average Latency (ms)',
+        data: avgLatencies,
+        borderColor: 'rgb(59, 130, 246)',
+        backgroundColor: 'rgba(59, 130, 246, 0.1)',
+        borderWidth: 2,
+        fill: false,
+        tension: 0.4,
+      },
+      {
+        label: '95th Percentile (ms)',
+        data: p95Latencies,
+        borderColor: 'rgb(239, 68, 68)',
+        backgroundColor: 'rgba(239, 68, 68, 0.1)',
+        borderWidth: 2,
+        fill: false,
+        tension: 0.4,
+        borderDash: [5, 5],
+      },
+    ],
+  };
+
+  return { uptimeData, latencyData };
+}
+
 export function MonitorDetailsComponent({
   monitor,
 }: MonitorDetailsComponentProps) {
   const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRange>('24h');
+  const [isLoadingMetrics, setIsLoadingMetrics] = useState(false);
 
-  // Generate mock data and calculate stats
-  const checkResults = useMemo(
-    () => generateMockCheckResults(monitor.id, selectedTimeRange),
-    [monitor.id, selectedTimeRange]
-  );
+  const timeRangeOptions: {
+    value: TimeRange;
+    label: string;
+    description: string;
+  }[] = [
+    { value: '1h', label: 'Last Hour', description: 'Past 60 minutes' },
+    { value: '24h', label: 'Last 24 Hours', description: 'Past day' },
+    { value: '7d', label: 'Last 7 Days', description: 'Past week' },
+    { value: '30d', label: 'Last 30 Days', description: 'Past month' },
+  ];
+
+  // Generate mock data and calculate stats with loading simulation
+  const checkResults = useMemo(() => {
+    setIsLoadingMetrics(true);
+    const results = generateMockCheckResults(monitor.id, selectedTimeRange);
+    setTimeout(() => setIsLoadingMetrics(false), 300);
+    return results;
+  }, [monitor.id, selectedTimeRange]);
 
   const stats = useMemo(() => calculateStats(checkResults), [checkResults]);
+  const { uptimeData, latencyData } = useMemo(
+    () => prepareChartData(checkResults, selectedTimeRange),
+    [checkResults, selectedTimeRange]
+  );
 
   const lastChecked = monitor.lastCheckedAt
     ? formatRelative(new Date(monitor.lastCheckedAt), new Date())
@@ -120,12 +284,123 @@ export function MonitorDetailsComponent({
 
   const isUp = monitor.id.charCodeAt(0) % 2 === 0;
 
-  const timeRangeOptions: { value: TimeRange; label: string }[] = [
-    { value: '1h', label: 'Last Hour' },
-    { value: '24h', label: 'Last 24 Hours' },
-    { value: '7d', label: 'Last 7 Days' },
-    { value: '30d', label: 'Last 30 Days' },
-  ];
+  // Chart options
+  const uptimeChartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: {
+      mode: 'index' as const,
+      intersect: false,
+    },
+    plugins: {
+      title: {
+        display: true,
+        text: 'Uptime Percentage Over Time',
+        font: { size: 16, weight: 'bold' },
+        color: '#374151',
+      },
+      legend: {
+        display: false,
+      },
+      tooltip: {
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        titleColor: 'white',
+        bodyColor: 'white',
+        callbacks: {
+          label: function (context) {
+            return `Uptime: ${context.parsed.y.toFixed(2)}%`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        display: true,
+        title: {
+          display: true,
+          text: 'Time',
+          color: '#6B7280',
+        },
+        grid: {
+          color: 'rgba(0, 0, 0, 0.1)',
+        },
+      },
+      y: {
+        display: true,
+        title: {
+          display: true,
+          text: 'Uptime %',
+          color: '#6B7280',
+        },
+        min: 0,
+        max: 100,
+        grid: {
+          color: 'rgba(0, 0, 0, 0.1)',
+        },
+      },
+    },
+  };
+
+  const latencyChartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: {
+      mode: 'index' as const,
+      intersect: false,
+    },
+    plugins: {
+      title: {
+        display: true,
+        text: 'Response Time Trends',
+        font: { size: 16, weight: 'bold' },
+        color: '#374151',
+      },
+      legend: {
+        display: true,
+        position: 'top' as const,
+      },
+      tooltip: {
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        titleColor: 'white',
+        bodyColor: 'white',
+        callbacks: {
+          label: function (context) {
+            return `${context.dataset.label}: ${context.parsed.y}ms`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        display: true,
+        title: {
+          display: true,
+          text: 'Time',
+          color: '#6B7280',
+        },
+        grid: {
+          color: 'rgba(0, 0, 0, 0.1)',
+        },
+      },
+      y: {
+        display: true,
+        title: {
+          display: true,
+          text: 'Response Time (ms)',
+          color: '#6B7280',
+        },
+        min: 0,
+        grid: {
+          color: 'rgba(0, 0, 0, 0.1)',
+        },
+      },
+    },
+  };
+
+  // Handle time range change
+  const handleTimeRangeChange = (newRange: TimeRange) => {
+    setSelectedTimeRange(newRange);
+  };
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -209,40 +484,150 @@ export function MonitorDetailsComponent({
         </div>
       </div>
 
-      {/* Time Range Selector */}
-      <div className="mb-6">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-            Time Range:
-          </span>
-          <select
-            value={selectedTimeRange}
-            onChange={(e) => setSelectedTimeRange(e.target.value as TimeRange)}
-            className="px-3 py-1 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
+      {/* Enhanced Time Range Selector */}
+      <div className="mb-8">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Time Range:
+            </span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              ({stats.totalChecks} total checks)
+            </span>
+          </div>
+
+          {/* Button Group for Time Range Selection */}
+          <div className="flex rounded-lg bg-gray-100 dark:bg-gray-800 p-1">
             {timeRangeOptions.map((option) => (
-              <option key={option.value} value={option.value}>
+              <button
+                key={option.value}
+                onClick={() => handleTimeRangeChange(option.value)}
+                className={`px-3 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
+                  selectedTimeRange === option.value
+                    ? 'bg-white dark:bg-gray-700 text-blue-600 dark:text-blue-400 shadow-sm'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+                title={option.description}
+              >
                 {option.label}
-              </option>
+              </button>
             ))}
-          </select>
+          </div>
+
+          {/* Loading indicator */}
+          {isLoadingMetrics && (
+            <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+              <div className="animate-spin rounded-full h-4 w-4 border-2 border-blue-500 border-t-transparent"></div>
+              Updating...
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Performance Metrics */}
+      {/* Charts Section */}
+      <div className="mb-8 space-y-8">
+        {/* Uptime Chart */}
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
+          {isLoadingMetrics ? (
+            <div className="flex items-center justify-center h-64">
+              <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-500 border-t-transparent"></div>
+              <span className="ml-2 text-gray-500 dark:text-gray-400">
+                Loading chart data...
+              </span>
+            </div>
+          ) : uptimeData ? (
+            <div className="h-64">
+              <Line data={uptimeData} options={uptimeChartOptions} />
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400">
+              <svg
+                className="w-12 h-12 mb-4 opacity-50"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                />
+              </svg>
+              <p className="text-lg font-medium mb-2">
+                No uptime data available
+              </p>
+              <p className="text-sm">
+                Data will appear once monitoring checks are performed
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Latency Chart */}
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
+          {isLoadingMetrics ? (
+            <div className="flex items-center justify-center h-64">
+              <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-500 border-t-transparent"></div>
+              <span className="ml-2 text-gray-500 dark:text-gray-400">
+                Loading chart data...
+              </span>
+            </div>
+          ) : latencyData ? (
+            <div className="h-64">
+              <Line data={latencyData} options={latencyChartOptions} />
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400">
+              <svg
+                className="w-12 h-12 mb-4 opacity-50"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+                />
+              </svg>
+              <p className="text-lg font-medium mb-2">
+                No latency data available
+              </p>
+              <p className="text-sm">
+                Response time trends will appear once monitoring data is
+                collected
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Performance Metrics with Animation */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         {/* Uptime */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
           <div className="flex items-center justify-between mb-2">
             <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
               Uptime
             </h3>
             <div
-              className={`w-3 h-3 rounded-full ${stats.uptimePercentage >= 99 ? 'bg-green-500' : stats.uptimePercentage >= 95 ? 'bg-yellow-500' : 'bg-red-500'}`}
+              className={`w-3 h-3 rounded-full transition-colors duration-300 ${
+                stats.uptimePercentage >= 99
+                  ? 'bg-green-500'
+                  : stats.uptimePercentage >= 95
+                    ? 'bg-yellow-500'
+                    : 'bg-red-500'
+              }`}
             ></div>
           </div>
-          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-            {stats.uptimePercentage.toFixed(2)}%
+          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-all duration-500">
+            {isLoadingMetrics ? (
+              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-8 w-20 rounded"></div>
+            ) : (
+              `${stats.uptimePercentage.toFixed(2)}%`
+            )}
           </div>
           <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
             {stats.totalChecks - stats.errorCount} / {stats.totalChecks} checks
@@ -251,17 +636,27 @@ export function MonitorDetailsComponent({
         </div>
 
         {/* Average Latency */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
           <div className="flex items-center justify-between mb-2">
             <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
               Avg Latency
             </h3>
             <div
-              className={`w-3 h-3 rounded-full ${stats.averageLatency <= 200 ? 'bg-green-500' : stats.averageLatency <= 500 ? 'bg-yellow-500' : 'bg-red-500'}`}
+              className={`w-3 h-3 rounded-full transition-colors duration-300 ${
+                stats.averageLatency <= 200
+                  ? 'bg-green-500'
+                  : stats.averageLatency <= 500
+                    ? 'bg-yellow-500'
+                    : 'bg-red-500'
+              }`}
             ></div>
           </div>
-          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-            {stats.averageLatency}ms
+          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-all duration-500">
+            {isLoadingMetrics ? (
+              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-8 w-20 rounded"></div>
+            ) : (
+              `${stats.averageLatency}ms`
+            )}
           </div>
           <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
             Average response time
@@ -269,17 +664,27 @@ export function MonitorDetailsComponent({
         </div>
 
         {/* 95th Percentile */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
           <div className="flex items-center justify-between mb-2">
             <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
               95th Percentile
             </h3>
             <div
-              className={`w-3 h-3 rounded-full ${stats.p95Latency <= 300 ? 'bg-green-500' : stats.p95Latency <= 800 ? 'bg-yellow-500' : 'bg-red-500'}`}
+              className={`w-3 h-3 rounded-full transition-colors duration-300 ${
+                stats.p95Latency <= 300
+                  ? 'bg-green-500'
+                  : stats.p95Latency <= 800
+                    ? 'bg-yellow-500'
+                    : 'bg-red-500'
+              }`}
             ></div>
           </div>
-          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-            {stats.p95Latency}ms
+          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-all duration-500">
+            {isLoadingMetrics ? (
+              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-8 w-20 rounded"></div>
+            ) : (
+              `${stats.p95Latency}ms`
+            )}
           </div>
           <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
             95% of requests faster than
@@ -287,20 +692,33 @@ export function MonitorDetailsComponent({
         </div>
 
         {/* Error Count */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
           <div className="flex items-center justify-between mb-2">
             <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
               Errors
             </h3>
             <div
-              className={`w-3 h-3 rounded-full ${stats.errorCount === 0 ? 'bg-green-500' : stats.errorCount <= 5 ? 'bg-yellow-500' : 'bg-red-500'}`}
+              className={`w-3 h-3 rounded-full transition-colors duration-300 ${
+                stats.errorCount === 0
+                  ? 'bg-green-500'
+                  : stats.errorCount <= 5
+                    ? 'bg-yellow-500'
+                    : 'bg-red-500'
+              }`}
             ></div>
           </div>
-          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-            {stats.errorCount}
+          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-all duration-500">
+            {isLoadingMetrics ? (
+              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-8 w-16 rounded"></div>
+            ) : (
+              stats.errorCount
+            )}
           </div>
           <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            Failed checks in time range
+            Failed checks in{' '}
+            {timeRangeOptions
+              .find((opt) => opt.value === selectedTimeRange)
+              ?.description.toLowerCase()}
           </div>
         </div>
       </div>
@@ -308,12 +726,22 @@ export function MonitorDetailsComponent({
       {/* Recent Check Results */}
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
         <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-            Recent Checks
-          </h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            Showing last {Math.min(10, checkResults.length)} checks
-          </p>
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                Recent Checks
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Showing last {Math.min(10, checkResults.length)} checks from{' '}
+                {timeRangeOptions
+                  .find((opt) => opt.value === selectedTimeRange)
+                  ?.description.toLowerCase()}
+              </p>
+            </div>
+            {isLoadingMetrics && (
+              <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-500 border-t-transparent"></div>
+            )}
+          </div>
         </div>
         <div className="overflow-x-auto">
           <table className="w-full">
@@ -334,38 +762,56 @@ export function MonitorDetailsComponent({
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-              {checkResults
-                .slice(-10)
-                .reverse()
-                .map((result) => (
-                  <tr
-                    key={result.id}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-700"
-                  >
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                      {new Date(result.timestamp).toLocaleString()}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                          result.status === 'UP'
-                            ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-                            : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
-                        }`}
+              {isLoadingMetrics
+                ? // Loading skeleton
+                  Array.from({ length: 5 }).map((_, i) => (
+                    <tr key={i}>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-4 w-32 rounded"></div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-6 w-12 rounded-full"></div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-4 w-16 rounded"></div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-4 w-12 rounded"></div>
+                      </td>
+                    </tr>
+                  ))
+                : checkResults
+                    .slice(-10)
+                    .reverse()
+                    .map((result) => (
+                      <tr
+                        key={result.id}
+                        className="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-150"
                       >
-                        {result.status}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                      {result.responseTimeMs
-                        ? `${result.responseTimeMs}ms`
-                        : '-'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-900 dark:text-gray-100">
-                      {result.statusCode || '-'}
-                    </td>
-                  </tr>
-                ))}
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                          {new Date(result.timestamp).toLocaleString()}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <span
+                            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                              result.status === 'UP'
+                                ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                                : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                            }`}
+                          >
+                            {result.status}
+                          </span>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                          {result.responseTimeMs
+                            ? `${result.responseTimeMs}ms`
+                            : '-'}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-900 dark:text-gray-100">
+                          {result.statusCode || '-'}
+                        </td>
+                      </tr>
+                    ))}
             </tbody>
           </table>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -477,9 +477,11 @@
     "apps/frontend": {
       "version": "0.1.0",
       "dependencies": {
+        "chart.js": "^4.5.0",
         "date-fns": "^4.1.0",
         "next": "15.3.5",
         "react": "^19.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
@@ -3060,6 +3062,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -7605,6 +7613,18 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -14217,6 +14237,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {


### PR DESCRIPTION
### Summary
- Implemented visual charts for uptime % and latency (average + p95) using Chart.js
- Charts dynamically update when the time range changes
- Added empty state message when no data is available

### How to Test
1. Start dev server
2. Open /dashboard/monitors/<id>
3. Change time range and verify charts update
4. If monitor has no data, confirm empty state message is shown
