### PR TITLE
feat(ui): add error handling and loading states (#5)

### DIFF
--- a/apps/frontend/src/app/dashboard/monitors/page.tsx
+++ b/apps/frontend/src/app/dashboard/monitors/page.tsx
@@ -1,36 +1,186 @@
+'use client';
+
+import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import monitors from '@/mocks/monitors.json';
 import { MonitorCard } from '@/components/monitors/MonitorCard';
+import { SkeletonLoader } from '@/components/ui/SkeletonLoader';
+import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import { useAsyncData, simulateApiCall } from '@/hooks/useAsyncData';
 import type { Monitor } from '@/types/monitor';
+
+async function fetchMonitors(userId: string): Promise<Monitor[]> {
+  // Simulate API call with mock data
+  const userMonitors = monitors.filter((m) => m.user?.id === userId);
+  return simulateApiCall(userMonitors as Monitor[], {
+    delay: 1000,
+    // Uncomment to test error handling
+    // shouldFail: true
+  });
+}
 
 export default function MonitorsPage() {
   const currentUserId = 'user-uuid-001';
-  const myMonitors = monitors.filter((m) => m.user?.id === currentUserId);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const fetchMonitorsFn = useCallback(
+    () => fetchMonitors(currentUserId),
+    [currentUserId]
+  );
+
+  const {
+    data: myMonitors,
+    loading,
+    error,
+    retry,
+  } = useAsyncData<Monitor[]>(fetchMonitorsFn, [refreshKey], {
+    simulateDelay: 1000,
+    simulateErrorRate: 0, // Set to 0.2 to test error handling (20% error rate)
+    retryCount: 3,
+    retryDelay: 1000,
+  });
+
+  const handleRefresh = () => {
+    setRefreshKey((prev) => prev + 1);
+  };
 
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-          Monitors
-        </h1>
-        <Link
-          href="/dashboard/monitors/new"
-          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-        >
-          Add Monitor
-        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Monitors
+          </h1>
+          {!loading && !error && myMonitors && (
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              {myMonitors.length} active monitor
+              {myMonitors.length !== 1 ? 's' : ''}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {!loading && !error && (
+            <button
+              onClick={handleRefresh}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+              title="Refresh monitors"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                />
+              </svg>
+              Refresh
+            </button>
+          )}
+          <Link
+            href="/dashboard/monitors/new"
+            className="inline-flex items-center gap-2 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            Add Monitor
+          </Link>
+        </div>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {myMonitors.length === 0 ? (
-          <p className="text-gray-600 dark:text-gray-400">
-            No monitors available. Click &quot;Add Monitor&quot; to create one.
-          </p>
-        ) : (
-          myMonitors.map((monitor) => (
-            <MonitorCard key={monitor.id} monitor={monitor as Monitor} />
-          ))
-        )}
-      </div>
+
+      {loading && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <SkeletonLoader variant="card" count={6} />
+        </div>
+      )}
+
+      {error && !loading && (
+        <ErrorDisplay
+          title="Failed to load monitors"
+          message="We couldn't fetch your monitors. Please check your connection and try again."
+          error={error}
+          onRetry={retry}
+        />
+      )}
+
+      {!loading && !error && myMonitors && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {myMonitors.length === 0 ? (
+            <div className="col-span-full">
+              <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-12 text-center">
+                <svg
+                  className="w-16 h-16 mx-auto mb-4 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                  />
+                </svg>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                  No monitors yet
+                </h3>
+                <p className="text-gray-600 dark:text-gray-400 mb-6">
+                  Get started by creating your first monitor to track your
+                  services.
+                </p>
+                <Link
+                  href="/dashboard/monitors/new"
+                  className="inline-flex items-center gap-2 bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 transition-colors"
+                >
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 4v16m8-8H4"
+                    />
+                  </svg>
+                  Create your first monitor
+                </Link>
+              </div>
+            </div>
+          ) : (
+            myMonitors.map((monitor) => (
+              <MonitorCard key={monitor.id} monitor={monitor} />
+            ))
+          )}
+        </div>
+      )}
+
+      {/* Loading state indicator in footer */}
+      {loading && (
+        <div className="fixed bottom-4 right-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg px-4 py-3 flex items-center gap-3">
+          <div className="animate-spin rounded-full h-4 w-4 border-2 border-blue-500 border-t-transparent" />
+          <span className="text-sm text-gray-600 dark:text-gray-400">
+            Loading monitors...
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -24,3 +24,59 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Custom animations */
+@keyframes progress-bar {
+  0% {
+    width: 0%;
+  }
+
+  50% {
+    width: 70%;
+  }
+
+  100% {
+    width: 100%;
+  }
+}
+
+.animate-progress-bar {
+  animation: progress-bar 2s ease-in-out infinite;
+}
+
+/* Smooth fade transitions */
+.fade-in {
+  animation: fadeIn 0.3s ease-in;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Skeleton animation enhancement */
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.animate-shimmer {
+  background: linear-gradient(90deg,
+      rgba(200, 200, 200, 0.2) 25%,
+      rgba(200, 200, 200, 0.3) 50%,
+      rgba(200, 200, 200, 0.2) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}

--- a/apps/frontend/src/components/monitors/MonitorCard.tsx
+++ b/apps/frontend/src/components/monitors/MonitorCard.tsx
@@ -6,6 +6,12 @@ interface MonitorCardProps {
   monitor: Monitor;
 }
 
+
+interface MonitorCardProps {
+  monitor: Monitor;
+  onRefresh?: (monitorId: string) => Promise<void>;
+}
+
 export function MonitorCard({ monitor }: MonitorCardProps) {
   const lastChecked = monitor.lastCheckedAt
     ? formatRelative(new Date(monitor.lastCheckedAt), new Date())

--- a/apps/frontend/src/components/monitors/MonitorDetailsComponent.tsx
+++ b/apps/frontend/src/components/monitors/MonitorDetailsComponent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import type {
   Monitor,
   CheckResult,
@@ -9,6 +9,10 @@ import type {
 } from '@/types/monitor';
 import { formatRelative } from 'date-fns/formatRelative';
 import Link from 'next/link';
+import { SkeletonLoader } from '@/components/ui/SkeletonLoader';
+import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { useAsyncData, simulateApiCall } from '@/hooks/useAsyncData';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -38,10 +42,10 @@ interface MonitorDetailsComponentProps {
 }
 
 // Helper function to generate mock check results for demonstration
-function generateMockCheckResults(
+async function fetchCheckResults(
   monitorId: string,
   timeRange: TimeRange
-): CheckResult[] {
+): Promise<CheckResult[]> {
   const now = new Date();
   const results: CheckResult[] = [];
 
@@ -72,10 +76,8 @@ function generateMockCheckResults(
 
   for (let i = 0; i < checks; i++) {
     const timestamp = new Date(now.getTime() - i * intervalMinutes * 60 * 1000);
-
-    // Use monitor ID to create consistent but varied results
     const seed = monitorId.charCodeAt(0) + i;
-    const isUp = seed % 7 !== 0; // ~85% uptime
+    const isUp = seed % 7 !== 0;
     const baseLatency = 100 + (seed % 200);
     const latency = isUp ? baseLatency + Math.random() * 100 : undefined;
 
@@ -89,7 +91,12 @@ function generateMockCheckResults(
     });
   }
 
-  return results.reverse(); // Oldest first
+  // Simulate API call
+  return simulateApiCall(results.reverse(), {
+    delay: 600,
+    // Uncomment to test error handling
+    // shouldFail: true
+  });
 }
 
 // Calculate monitor statistics from check results
@@ -130,7 +137,6 @@ function prepareChartData(checkResults: CheckResult[], timeRange: TimeRange) {
     return { uptimeData: null, latencyData: null };
   }
 
-  // Group data points for better visualization
   const groupSize =
     timeRange === '1h'
       ? 6
@@ -171,7 +177,6 @@ function prepareChartData(checkResults: CheckResult[], timeRange: TimeRange) {
     const p95Latency =
       sortedLatencies.length > 0 ? sortedLatencies[p95Index] || 0 : 0;
 
-    // Format label based on time range
     const date = new Date(firstCheck.timestamp);
     let label = '';
 
@@ -251,7 +256,7 @@ export function MonitorDetailsComponent({
   monitor,
 }: MonitorDetailsComponentProps) {
   const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRange>('24h');
-  const [isLoadingMetrics, setIsLoadingMetrics] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const timeRangeOptions: {
     value: TimeRange;
@@ -264,17 +269,38 @@ export function MonitorDetailsComponent({
     { value: '30d', label: 'Last 30 Days', description: 'Past month' },
   ];
 
-  // Generate mock data and calculate stats with loading simulation
-  const checkResults = useMemo(() => {
-    setIsLoadingMetrics(true);
-    const results = generateMockCheckResults(monitor.id, selectedTimeRange);
-    setTimeout(() => setIsLoadingMetrics(false), 300);
-    return results;
-  }, [monitor.id, selectedTimeRange]);
+  // Fetch check results with loading and error handling
+  const fetchCheckResultsFn = useCallback(
+    () => fetchCheckResults(monitor.id, selectedTimeRange),
+    [monitor.id, selectedTimeRange]
+  );
 
-  const stats = useMemo(() => calculateStats(checkResults), [checkResults]);
+  const {
+    data: checkResults,
+    loading: isLoadingMetrics,
+    error: metricsError,
+    retry: retryMetrics,
+  } = useAsyncData<CheckResult[]>(
+    fetchCheckResultsFn,
+    [selectedTimeRange, refreshKey],
+    {
+      simulateDelay: 600,
+      simulateErrorRate: 0, // Set to 0.2 to test error handling
+      retryCount: 3,
+      retryDelay: 1000,
+    }
+  );
+
+  const stats = useMemo(
+    () => (checkResults ? calculateStats(checkResults) : null),
+    [checkResults]
+  );
+
   const { uptimeData, latencyData } = useMemo(
-    () => prepareChartData(checkResults, selectedTimeRange),
+    () =>
+      checkResults
+        ? prepareChartData(checkResults, selectedTimeRange)
+        : { uptimeData: null, latencyData: null },
     [checkResults, selectedTimeRange]
   );
 
@@ -397,9 +423,12 @@ export function MonitorDetailsComponent({
     },
   };
 
-  // Handle time range change
   const handleTimeRangeChange = (newRange: TimeRange) => {
     setSelectedTimeRange(newRange);
+  };
+
+  const handleRefresh = () => {
+    setRefreshKey((prev) => prev + 1);
   };
 
   return (
@@ -441,6 +470,26 @@ export function MonitorDetailsComponent({
               </span>
             </div>
           </div>
+          <button
+            onClick={handleRefresh}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            disabled={isLoadingMetrics}
+          >
+            <svg
+              className={`w-4 h-4 ${isLoadingMetrics ? 'animate-spin' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+            Refresh
+          </button>
         </div>
 
         {/* Monitor Metadata */}
@@ -491,9 +540,11 @@ export function MonitorDetailsComponent({
             <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
               Time Range:
             </span>
-            <span className="text-xs text-gray-500 dark:text-gray-400">
-              ({stats.totalChecks} total checks)
-            </span>
+            {stats && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                ({stats.totalChecks} total checks)
+              </span>
+            )}
           </div>
 
           {/* Button Group for Time Range Selection */}
@@ -517,210 +568,163 @@ export function MonitorDetailsComponent({
           {/* Loading indicator */}
           {isLoadingMetrics && (
             <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-              <div className="animate-spin rounded-full h-4 w-4 border-2 border-blue-500 border-t-transparent"></div>
+              <LoadingSpinner size="small" message="" />
               Updating...
             </div>
           )}
         </div>
       </div>
 
+      {/* Error Display for Metrics */}
+      {metricsError && (
+        <div className="mb-8">
+          <ErrorDisplay
+            title="Failed to load metrics"
+            message="We couldn't fetch the monitoring data. Please try again."
+            error={metricsError}
+            onRetry={retryMetrics}
+            compact
+          />
+        </div>
+      )}
+
       {/* Charts Section */}
       <div className="mb-8 space-y-8">
         {/* Uptime Chart */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
-          {isLoadingMetrics ? (
-            <div className="flex items-center justify-center h-64">
-              <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-500 border-t-transparent"></div>
-              <span className="ml-2 text-gray-500 dark:text-gray-400">
-                Loading chart data...
-              </span>
-            </div>
-          ) : uptimeData ? (
+        {isLoadingMetrics ? (
+          <SkeletonLoader variant="chart" />
+        ) : !metricsError && uptimeData ? (
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
             <div className="h-64">
               <Line data={uptimeData} options={uptimeChartOptions} />
             </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400">
-              <svg
-                className="w-12 h-12 mb-4 opacity-50"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
-                />
-              </svg>
-              <p className="text-lg font-medium mb-2">
-                No uptime data available
-              </p>
-              <p className="text-sm">
-                Data will appear once monitoring checks are performed
-              </p>
-            </div>
-          )}
-        </div>
+          </div>
+        ) : null}
 
         {/* Latency Chart */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
-          {isLoadingMetrics ? (
-            <div className="flex items-center justify-center h-64">
-              <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-500 border-t-transparent"></div>
-              <span className="ml-2 text-gray-500 dark:text-gray-400">
-                Loading chart data...
-              </span>
-            </div>
-          ) : latencyData ? (
+        {isLoadingMetrics ? (
+          <SkeletonLoader variant="chart" />
+        ) : !metricsError && latencyData ? (
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
             <div className="h-64">
               <Line data={latencyData} options={latencyChartOptions} />
             </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400">
-              <svg
-                className="w-12 h-12 mb-4 opacity-50"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
-                />
-              </svg>
-              <p className="text-lg font-medium mb-2">
-                No latency data available
-              </p>
-              <p className="text-sm">
-                Response time trends will appear once monitoring data is
-                collected
-              </p>
-            </div>
-          )}
-        </div>
+          </div>
+        ) : null}
       </div>
 
-      {/* Performance Metrics with Animation */}
+      {/* Performance Metrics */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        {/* Uptime */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
-          <div className="flex items-center justify-between mb-2">
-            <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-              Uptime
-            </h3>
-            <div
-              className={`w-3 h-3 rounded-full transition-colors duration-300 ${
-                stats.uptimePercentage >= 99
-                  ? 'bg-green-500'
-                  : stats.uptimePercentage >= 95
-                    ? 'bg-yellow-500'
-                    : 'bg-red-500'
-              }`}
-            ></div>
-          </div>
-          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-all duration-500">
-            {isLoadingMetrics ? (
-              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-8 w-20 rounded"></div>
-            ) : (
-              `${stats.uptimePercentage.toFixed(2)}%`
-            )}
-          </div>
-          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            {stats.totalChecks - stats.errorCount} / {stats.totalChecks} checks
-            successful
-          </div>
-        </div>
+        {isLoadingMetrics ? (
+          <>
+            <SkeletonLoader variant="metric" />
+            <SkeletonLoader variant="metric" />
+            <SkeletonLoader variant="metric" />
+            <SkeletonLoader variant="metric" />
+          </>
+        ) : stats && !metricsError ? (
+          <>
+            {/* Uptime */}
+            <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Uptime
+                </h3>
+                <div
+                  className={`w-3 h-3 rounded-full transition-colors duration-300 ${
+                    stats.uptimePercentage >= 99
+                      ? 'bg-green-500'
+                      : stats.uptimePercentage >= 95
+                        ? 'bg-yellow-500'
+                        : 'bg-red-500'
+                  }`}
+                ></div>
+              </div>
+              <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {stats.uptimePercentage.toFixed(2)}%
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                {stats.totalChecks - stats.errorCount} / {stats.totalChecks}{' '}
+                checks successful
+              </div>
+            </div>
 
-        {/* Average Latency */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
-          <div className="flex items-center justify-between mb-2">
-            <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-              Avg Latency
-            </h3>
-            <div
-              className={`w-3 h-3 rounded-full transition-colors duration-300 ${
-                stats.averageLatency <= 200
-                  ? 'bg-green-500'
-                  : stats.averageLatency <= 500
-                    ? 'bg-yellow-500'
-                    : 'bg-red-500'
-              }`}
-            ></div>
-          </div>
-          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-all duration-500">
-            {isLoadingMetrics ? (
-              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-8 w-20 rounded"></div>
-            ) : (
-              `${stats.averageLatency}ms`
-            )}
-          </div>
-          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            Average response time
-          </div>
-        </div>
+            {/* Average Latency */}
+            <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Avg Latency
+                </h3>
+                <div
+                  className={`w-3 h-3 rounded-full transition-colors duration-300 ${
+                    stats.averageLatency <= 200
+                      ? 'bg-green-500'
+                      : stats.averageLatency <= 500
+                        ? 'bg-yellow-500'
+                        : 'bg-red-500'
+                  }`}
+                ></div>
+              </div>
+              <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {stats.averageLatency}ms
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Average response time
+              </div>
+            </div>
 
-        {/* 95th Percentile */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
-          <div className="flex items-center justify-between mb-2">
-            <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-              95th Percentile
-            </h3>
-            <div
-              className={`w-3 h-3 rounded-full transition-colors duration-300 ${
-                stats.p95Latency <= 300
-                  ? 'bg-green-500'
-                  : stats.p95Latency <= 800
-                    ? 'bg-yellow-500'
-                    : 'bg-red-500'
-              }`}
-            ></div>
-          </div>
-          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-all duration-500">
-            {isLoadingMetrics ? (
-              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-8 w-20 rounded"></div>
-            ) : (
-              `${stats.p95Latency}ms`
-            )}
-          </div>
-          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            95% of requests faster than
-          </div>
-        </div>
+            {/* 95th Percentile */}
+            <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  95th Percentile
+                </h3>
+                <div
+                  className={`w-3 h-3 rounded-full transition-colors duration-300 ${
+                    stats.p95Latency <= 300
+                      ? 'bg-green-500'
+                      : stats.p95Latency <= 800
+                        ? 'bg-yellow-500'
+                        : 'bg-red-500'
+                  }`}
+                ></div>
+              </div>
+              <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {stats.p95Latency}ms
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                95% of requests faster than
+              </div>
+            </div>
 
-        {/* Error Count */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
-          <div className="flex items-center justify-between mb-2">
-            <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-              Errors
-            </h3>
-            <div
-              className={`w-3 h-3 rounded-full transition-colors duration-300 ${
-                stats.errorCount === 0
-                  ? 'bg-green-500'
-                  : stats.errorCount <= 5
-                    ? 'bg-yellow-500'
-                    : 'bg-red-500'
-              }`}
-            ></div>
-          </div>
-          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-all duration-500">
-            {isLoadingMetrics ? (
-              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-8 w-16 rounded"></div>
-            ) : (
-              stats.errorCount
-            )}
-          </div>
-          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            Failed checks in{' '}
-            {timeRangeOptions
-              .find((opt) => opt.value === selectedTimeRange)
-              ?.description.toLowerCase()}
-          </div>
-        </div>
+            {/* Error Count */}
+            <div className="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 transition-all duration-300 hover:shadow-md">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Errors
+                </h3>
+                <div
+                  className={`w-3 h-3 rounded-full transition-colors duration-300 ${
+                    stats.errorCount === 0
+                      ? 'bg-green-500'
+                      : stats.errorCount <= 5
+                        ? 'bg-yellow-500'
+                        : 'bg-red-500'
+                  }`}
+                ></div>
+              </div>
+              <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {stats.errorCount}
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Failed checks in{' '}
+                {timeRangeOptions
+                  .find((opt) => opt.value === selectedTimeRange)
+                  ?.description.toLowerCase()}
+              </div>
+            </div>
+          </>
+        ) : null}
       </div>
 
       {/* Recent Check Results */}
@@ -731,16 +735,16 @@ export function MonitorDetailsComponent({
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                 Recent Checks
               </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Showing last {Math.min(10, checkResults.length)} checks from{' '}
-                {timeRangeOptions
-                  .find((opt) => opt.value === selectedTimeRange)
-                  ?.description.toLowerCase()}
-              </p>
+              {checkResults && !metricsError && (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Showing last {Math.min(10, checkResults.length)} checks from{' '}
+                  {timeRangeOptions
+                    .find((opt) => opt.value === selectedTimeRange)
+                    ?.description.toLowerCase()}
+                </p>
+              )}
             </div>
-            {isLoadingMetrics && (
-              <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-500 border-t-transparent"></div>
-            )}
+            {isLoadingMetrics && <LoadingSpinner size="small" message="" />}
           </div>
         </div>
         <div className="overflow-x-auto">
@@ -762,56 +766,44 @@ export function MonitorDetailsComponent({
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-              {isLoadingMetrics
-                ? // Loading skeleton
-                  Array.from({ length: 5 }).map((_, i) => (
-                    <tr key={i}>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-4 w-32 rounded"></div>
+              {isLoadingMetrics ? (
+                <>
+                  <SkeletonLoader variant="row" count={5} />
+                </>
+              ) : checkResults && !metricsError ? (
+                checkResults
+                  .slice(-10)
+                  .reverse()
+                  .map((result) => (
+                    <tr
+                      key={result.id}
+                      className="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-150"
+                    >
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {new Date(result.timestamp).toLocaleString()}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-6 w-12 rounded-full"></div>
+                        <span
+                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                            result.status === 'UP'
+                              ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                              : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                          }`}
+                        >
+                          {result.status}
+                        </span>
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-4 w-16 rounded"></div>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {result.responseTimeMs
+                          ? `${result.responseTimeMs}ms`
+                          : '-'}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-4 w-12 rounded"></div>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-900 dark:text-gray-100">
+                        {result.statusCode || '-'}
                       </td>
                     </tr>
                   ))
-                : checkResults
-                    .slice(-10)
-                    .reverse()
-                    .map((result) => (
-                      <tr
-                        key={result.id}
-                        className="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-150"
-                      >
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                          {new Date(result.timestamp).toLocaleString()}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <span
-                            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                              result.status === 'UP'
-                                ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-                                : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
-                            }`}
-                          >
-                            {result.status}
-                          </span>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                          {result.responseTimeMs
-                            ? `${result.responseTimeMs}ms`
-                            : '-'}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-900 dark:text-gray-100">
-                          {result.statusCode || '-'}
-                        </td>
-                      </tr>
-                    ))}
+              ) : null}
             </tbody>
           </table>
         </div>

--- a/apps/frontend/src/components/providers/GlobalLoadingProvider.tsx
+++ b/apps/frontend/src/components/providers/GlobalLoadingProvider.tsx
@@ -1,0 +1,66 @@
+// apps/frontend/src/components/providers/GlobalLoadingProvider.tsx
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  ReactNode,
+} from 'react';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+
+interface GlobalLoadingContextType {
+  isLoading: boolean;
+  showLoading: (message?: string) => void;
+  hideLoading: () => void;
+}
+
+const GlobalLoadingContext = createContext<
+  GlobalLoadingContextType | undefined
+>(undefined);
+
+export function useGlobalLoading() {
+  const context = useContext(GlobalLoadingContext);
+  if (!context) {
+    throw new Error(
+      'useGlobalLoading must be used within GlobalLoadingProvider'
+    );
+  }
+  return context;
+}
+
+interface GlobalLoadingProviderProps {
+  children: ReactNode;
+}
+
+export function GlobalLoadingProvider({
+  children,
+}: GlobalLoadingProviderProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadingMessage, setLoadingMessage] = useState('Loading...');
+
+  const showLoading = useCallback((message = 'Loading...') => {
+    setLoadingMessage(message);
+    setIsLoading(true);
+  }, []);
+
+  const hideLoading = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
+  return (
+    <GlobalLoadingContext.Provider
+      value={{ isLoading, showLoading, hideLoading }}
+    >
+      {children}
+      {isLoading && (
+        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 flex flex-col items-center">
+            <LoadingSpinner size="large" message={loadingMessage} />
+          </div>
+        </div>
+      )}
+    </GlobalLoadingContext.Provider>
+  );
+}

--- a/apps/frontend/src/components/ui/ErrorDisplay.tsx
+++ b/apps/frontend/src/components/ui/ErrorDisplay.tsx
@@ -1,0 +1,121 @@
+interface ErrorDisplayProps {
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+  showRetry?: boolean;
+  error?: Error | null;
+  compact?: boolean;
+}
+
+export function ErrorDisplay({
+  title = 'Something went wrong',
+  message = 'We encountered an error while loading the data. Please try again.',
+  onRetry,
+  showRetry = true,
+  error,
+  compact = false,
+}: ErrorDisplayProps) {
+  // Log error details for debugging
+  if (error && process.env.NODE_ENV === 'development') {
+    console.error('Error details:', error);
+  }
+
+  if (compact) {
+    return (
+      <div className="flex items-center justify-between bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+        <div className="flex items-center gap-3">
+          <svg
+            className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <div>
+            <p className="text-sm font-medium text-red-800 dark:text-red-200">
+              {title}
+            </p>
+            <p className="text-xs text-red-600 dark:text-red-400 mt-0.5">
+              {message}
+            </p>
+          </div>
+        </div>
+        {showRetry && onRetry && (
+          <button
+            onClick={onRetry}
+            className="text-sm font-medium text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 transition-colors"
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12">
+      <div className="bg-red-50 dark:bg-red-900/20 rounded-full p-3 mb-4">
+        <svg
+          className="w-8 h-8 text-red-600 dark:text-red-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      </div>
+
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+        {title}
+      </h3>
+
+      <p className="text-sm text-gray-600 dark:text-gray-400 text-center max-w-md mb-6">
+        {message}
+      </p>
+
+      {error && process.env.NODE_ENV === 'development' && (
+        <details className="mb-4">
+          <summary className="text-xs text-gray-500 dark:text-gray-500 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300">
+            Error details
+          </summary>
+          <pre className="mt-2 text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded max-w-md overflow-x-auto">
+            {error.message || 'Unknown error'}
+          </pre>
+        </details>
+      )}
+
+      {showRetry && onRetry && (
+        <button
+          onClick={onRetry}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ui/LoadingSpinner.tsx
+++ b/apps/frontend/src/components/ui/LoadingSpinner.tsx
@@ -1,0 +1,30 @@
+interface LoadingSpinnerProps {
+  size?: 'small' | 'medium' | 'large';
+  message?: string;
+}
+
+export function LoadingSpinner({
+  size = 'medium',
+  message = 'Loading...',
+}: LoadingSpinnerProps) {
+  const sizeClasses = {
+    small: 'h-4 w-4 border-2',
+    medium: 'h-8 w-8 border-2',
+    large: 'h-12 w-12 border-3',
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <div
+        className={`animate-spin rounded-full border-blue-500 border-t-transparent ${sizeClasses[size]}`}
+        role="status"
+        aria-label="Loading"
+      />
+      {message && (
+        <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ui/SkeletonLoader.tsx
+++ b/apps/frontend/src/components/ui/SkeletonLoader.tsx
@@ -1,0 +1,103 @@
+interface SkeletonLoaderProps {
+  variant?: 'card' | 'row' | 'chart' | 'metric' | 'text';
+  count?: number;
+  className?: string;
+}
+
+export function SkeletonLoader({
+  variant = 'card',
+  count = 1,
+  className = '',
+}: SkeletonLoaderProps) {
+  const renderSkeleton = () => {
+    switch (variant) {
+      case 'card':
+        return (
+          <div
+            className={`border border-gray-200 rounded-lg p-4 dark:border-gray-700 ${className}`}
+          >
+            <div className="animate-pulse">
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <div className="h-5 bg-gray-300 dark:bg-gray-600 rounded w-32 mb-2" />
+                  <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-48" />
+                  <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-24 mt-2" />
+                </div>
+                <div className="text-right">
+                  <div className="h-6 bg-gray-300 dark:bg-gray-600 rounded-full w-12" />
+                  <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-16 mt-2" />
+                  <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-12 mt-1" />
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+
+      case 'row':
+        return (
+          <tr className={className}>
+            <td className="px-6 py-4 whitespace-nowrap">
+              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-4 w-32 rounded" />
+            </td>
+            <td className="px-6 py-4 whitespace-nowrap">
+              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-6 w-12 rounded-full" />
+            </td>
+            <td className="px-6 py-4 whitespace-nowrap">
+              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-4 w-16 rounded" />
+            </td>
+            <td className="px-6 py-4 whitespace-nowrap">
+              <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-4 w-12 rounded" />
+            </td>
+          </tr>
+        );
+
+      case 'chart':
+        return (
+          <div
+            className={`bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 ${className}`}
+          >
+            <div className="animate-pulse">
+              <div className="h-5 bg-gray-300 dark:bg-gray-600 rounded w-40 mb-4" />
+              <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+            </div>
+          </div>
+        );
+
+      case 'metric':
+        return (
+          <div
+            className={`bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-200 dark:border-gray-700 ${className}`}
+          >
+            <div className="animate-pulse">
+              <div className="flex items-center justify-between mb-2">
+                <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-24" />
+                <div className="h-3 w-3 bg-gray-300 dark:bg-gray-600 rounded-full" />
+              </div>
+              <div className="h-8 bg-gray-300 dark:bg-gray-600 rounded w-20 mb-1" />
+              <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-32" />
+            </div>
+          </div>
+        );
+
+      case 'text':
+        return (
+          <div className={`animate-pulse space-y-2 ${className}`}>
+            <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-full" />
+            <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-5/6" />
+            <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-4/6" />
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      {Array.from({ length: count }).map((_, index) => (
+        <div key={index}>{renderSkeleton()}</div>
+      ))}
+    </>
+  );
+}

--- a/apps/frontend/src/hooks/useAsyncData.ts
+++ b/apps/frontend/src/hooks/useAsyncData.ts
@@ -1,0 +1,115 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface UseAsyncDataOptions {
+  simulateDelay?: number;
+  simulateErrorRate?: number;
+  retryCount?: number;
+  retryDelay?: number;
+}
+
+interface UseAsyncDataResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+  retry: () => void;
+  refresh: () => void;
+}
+
+export function useAsyncData<T>(
+  fetchFn: () => Promise<T> | T,
+  deps: React.DependencyList = [],
+  options: UseAsyncDataOptions = {}
+): UseAsyncDataResult<T> {
+  const {
+    simulateDelay = 800,
+    simulateErrorRate = 0.3,
+    retryCount = 3,
+    retryDelay = 1000,
+  } = options;
+
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [attemptCount, setAttemptCount] = useState(0);
+  const [retryTrigger, setRetryTrigger] = useState(0);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Simulate network delay in development
+      if (process.env.NODE_ENV === 'development' && simulateDelay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, simulateDelay));
+      }
+
+      // Simulate random errors in development for testing
+      if (
+        process.env.NODE_ENV === 'development' &&
+        Math.random() < simulateErrorRate &&
+        attemptCount === 0 // Only simulate error on first attempt
+      ) {
+        throw new Error('Simulated network error for testing');
+      }
+
+      const result = await fetchFn();
+      setData(result);
+      setAttemptCount(0);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'An unexpected error occurred';
+      const error = new Error(errorMessage);
+
+      setError(error);
+
+      // Auto-retry logic
+      if (attemptCount < retryCount - 1) {
+        setTimeout(() => {
+          setAttemptCount((prev) => prev + 1);
+          setRetryTrigger((prev) => prev + 1);
+        }, retryDelay);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    fetchFn,
+    attemptCount,
+    retryCount,
+    retryDelay,
+    simulateDelay,
+    simulateErrorRate,
+  ]);
+
+  useEffect(() => {
+    fetchData();
+  }, [...deps, retryTrigger]);
+
+  const retry = useCallback(() => {
+    setAttemptCount(0);
+    setRetryTrigger((prev) => prev + 1);
+  }, []);
+
+  const refresh = useCallback(() => {
+    setAttemptCount(0);
+    fetchData();
+  }, [fetchData]);
+
+  return { data, loading, error, retry, refresh };
+}
+
+// Helper function to simulate API delays
+export async function simulateApiCall<T>(
+  data: T,
+  options: { delay?: number; shouldFail?: boolean } = {}
+): Promise<T> {
+  const { delay = 800, shouldFail = false } = options;
+
+  await new Promise((resolve) => setTimeout(resolve, delay));
+
+  if (shouldFail) {
+    throw new Error('API call failed');
+  }
+
+  return data;
+}


### PR DESCRIPTION
Added global loading and error handling for monitors list and details:

- Show skeleton/loader while fetching  
- Show error message with retry on failure  

## How to Test

1. Run frontend:

   ```bash
   cd apps/frontend
   npm run dev

2. Open /dashboard/monitors

3. Verify loading and error states

Closes [task 5](https://github.com/mahmoudhusam/mahmoudhusam/issues/5)
